### PR TITLE
Add GitHub Actions workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,16 @@
+name: 'test'
+
+on:
+  push:
+  pull_request:
+
+jobs:
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+      with:
+        submodules: recursive
+    - run: docker run --rm --privileged aptman/qus -s -- -p aarch64
+    - run: docker run --rm -tv $(pwd):/src aptman/dbhi:bionic-mambo-arm64 /src/ci.sh

--- a/ci.sh
+++ b/ci.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env sh
+
+set -e
+
+cd $(dirname "$0")
+
+echo "Build MAMBO"
+make all
+
+cd test
+
+echo "> Build load_store"
+make load_store
+
+echo "> Build mmap_munmap"
+make mmap_munmap
+
+echo "> Build mprotect_exec"
+make mprotect_exec
+
+echo "> Build self_modifying"
+make self_modifying
+
+echo "> Build signals"
+make signals
+
+set +e
+
+echo "> Execute load_store"
+./load_store
+
+echo "> Execute load_store on MAMBO"
+../dbm load_store
+
+echo "> Execute mmap_munmap"
+./mmap_munmap
+
+echo "> Execute mmap_munmap on MAMBO"
+../dbm mmap_munmap
+
+echo "> Execute mprotect_exec"
+./mprotect_exec
+
+echo "> Execute mprotect_exec on MAMBO"
+../dbm mprotect_exec
+
+echo "> Execute self_modifying"
+./self_modifying
+
+echo "> Execute self_modifying on MAMBO"
+../dbm self_modifying
+
+echo "> Execute signals"
+./signals
+
+echo "> Execute signals on MAMBO"
+../dbm signals
+
+echo "CI done"


### PR DESCRIPTION
In this PR:

- Latest upstreamed changes are pulled.
- A GitHub Actions workflow is added.

In the workflow, MAMBO is built, all the tests are built, and each of them is executed directly and on top of MAMBO. Since workers on GitHub Actions are x86-64, project [dbhi/qus](https://github.com/dbhi/qus) is used to load qemu-user in memory. This allows to use a Docker container which includes the dependencies for building and testing MAMBO. Precisely, image `aptman/dbhi:bionic-mambo` is used (see [dbhi/docker](https://github.com/dbhi/docker)).

It is to be noted that it would be possible to install qemu-user without dbhi/qus and to use images other than those maintained in dbhi/docker.

Some tests do fail because of unsupported features in QEMU, not because of MAMBO. That's why the workflow will end successfully regardless of the execution results. Only failing builds will make the workflow red.

FTR, this is the current status:

| | QEMU | QEMU+MAMBO |
|---|---|---|
| load_store | segfault | segfault |
| mmap_munmap | ok | ok |
| mprotect_exec | ok | aborted |
| self_modifying | ok | ok |
| signals | illegal instruction | aborted |

See logs of failing cases below. Note that in Aug 2018, `load_store` was reported to work without MAMBO (beehive-lab/mambo#19), which is not the case today. Moreover, because the version of QEMU in aptman/qus is updated periodically, the table above might change in the future.

```
> Execute load_store
Segmentation fault (core dumped)
```

```
> Execute load_store on MAMBO
Segmentation fault (core dumped)
```

```
> Execute mprotect_exec on MAMBO
main()
dbm: syscalls.c:343: syscall_handler_pre: Assertion `args[2] & PROT_READ' failed.
Aborted (core dumped)
```

```
> Execute signals
Simple signal handler: success
Signal after flushing the code cache: success
Test sigsuspend: success
Test against race conditions between code generation and signals: success
Test for missed signals: success
Test signal handling in fragments containing CB(N)Z: success
Test signal handling in fragments containing TB(N)Z: success
Test handling of a synchronous SIGTRAP signal: success
Test handling of a synchronous SIGILL signal: success
Test receiving SIGILL when no handler is installed
Illegal instruction (core dumped)
```

```
> Execute signals on MAMBO
Simple signal handler: success
Signal after flushing the code cache: success
Test sigsuspend: success
Test against race conditions between code generation and signals: dbm: dbm.c:590: addr_to_fragment_id: Assertion `(void *)addr < (((void *)&thread_data->code_cache) + sizeof(dbm_code_cache))' failed.
Aborted (core dumped)
```